### PR TITLE
Detect and override mixed terminal, array keys

### DIFF
--- a/spectron/Field.py
+++ b/spectron/Field.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+
+import logging
+
+from collections import defaultdict
+
+logger = logging.getLogger(__name__)
+
+
+class Field:
+    """Tracks `max` value and data type(s)."""
+
+    numeric_types = {"int", "float"}
+
+    def __init__(self, parent_key: str, value=None, *, str_numeric_override=False):
+        self.parent_key = parent_key
+        self.str_numeric_override = str_numeric_override
+        self.num_na = 0
+        self.dtype_max = {}
+        self.hist = defaultdict(int)
+        self.add(value)
+        self._test_ver = "4"
+
+    def push_warnings(self):
+        """Detect and log mixed dtypes."""
+
+        if len(self.hist.keys()) > 1:
+            if isinstance(self.parent_key, tuple):
+                ref_par_key = ".".join(self.parent_key)
+            else:
+                ref_par_key = self.parent_key
+
+            logger.warning(
+                f"[{ref_par_key}] dtypes detected {', '.join(sorted(self.hist.keys()))}"
+            )
+
+    @property
+    def dtype(self):
+        """Get data type conforming to spectrum requirements or with highest count.
+
+        If `str_numeric_override` is enabled and any strings have been seen, returned
+        dtype is forced as str.
+
+        If int and float have been seen, dtype defaults to float.
+        """
+
+        dtype = None
+        if self.hist:
+
+            if len(self.hist.keys()) == 1:
+                dtype = list(self.hist.keys())[0]
+            else:
+                numeric_intersect = self.numeric_types & self.hist.keys()
+
+                if numeric_intersect:
+                    if self.str_numeric_override and "str" in self.hist:
+                        dtype = "str"
+                    elif "float" in numeric_intersect:
+                        dtype = "float"
+
+            if not dtype:
+                dtype, _ = max(self.hist.items(), key=lambda t: t[1])
+
+        return dtype
+
+    def _get_max_comparable(self, prev_value, value, key_func):
+        """Get max value for inputs which can be compared."""
+
+        max_value = None
+        if prev_value is None:
+            max_value = value
+        else:
+            max_value = max(value, prev_value, key=key_func)
+        return max_value
+
+    def _compare_numeric(self, prev_value, value):
+        return self._get_max_comparable(prev_value, value, abs)
+
+    def _compare_str(self, prev_value, value):
+        return self._get_max_comparable(prev_value, value, len)
+
+    def _compare_other_types(self, prev_value, value):
+        return value
+
+    @property
+    def max_value(self):
+        """Get max value for current dtype."""
+
+        _dtype = self.dtype
+        is_numeric = _dtype in self.numeric_types
+
+        if is_numeric and self.numeric_types.issubset(self.hist.keys()):
+            val = self._compare_numeric(self.dtype_max["float"], self.dtype_max["int"])
+            return float(val)
+
+        return self.dtype_max.get(_dtype)
+
+    def _update_dtype_max(self, incoming_dtype, value):
+        """Detect dtype change and store diffs."""
+
+        if incoming_dtype in self.dtype_max:
+            prev_value = self.dtype_max[incoming_dtype]
+
+            comp_func = None
+            if incoming_dtype == "str":
+                comp_func = self._compare_str
+            elif incoming_dtype in self.numeric_types:
+                comp_func = self._compare_numeric
+            else:
+                comp_func = self._compare_other_types
+
+            self.dtype_max[incoming_dtype] = comp_func(prev_value, value)
+
+        else:
+            self.dtype_max[incoming_dtype] = value
+
+    def add(self, value):
+        """Add value to field and track dtype."""
+
+        if value is not None:
+            incoming_dtype = type(value).__name__
+            self._update_dtype_max(incoming_dtype, value)
+            self._dtype = incoming_dtype
+            self.hist[self._dtype] += 1
+        else:
+            self.num_na += 1

--- a/spectron/MaxDict.py
+++ b/spectron/MaxDict.py
@@ -7,8 +7,8 @@ from itertools import chain
 from typing import AbstractSet, Dict, Generator, List, Optional, Tuple
 
 from . import data_types
+from .Field import Field
 from .merge import construct_branch, extract_terminal_keys
-
 
 logger = logging.getLogger(__name__)
 
@@ -58,128 +58,6 @@ def is_parent(parent_key: Tuple[str], key: Tuple[str]) -> bool:
     """
 
     return len(key) > len(parent_key) and key[: len(parent_key)] == parent_key
-
-
-# --------------------------------------------------------------------------------------
-
-
-class Field:
-    """Tracks `max` value and data type(s)."""
-
-    numeric_types = {"int", "float"}
-
-    def __init__(self, parent_key: str, value=None, *, str_numeric_override=False):
-        self.parent_key = parent_key
-        self.str_numeric_override = str_numeric_override
-        self.num_na = 0
-        self.dtype_max = {}
-        self.hist = defaultdict(int)
-        self.add(value)
-        self._test_ver = "4"
-
-    def push_warnings(self):
-        """Detect and log mixed dtypes."""
-
-        if len(self.hist.keys()) > 1:
-            if isinstance(self.parent_key, tuple):
-                ref_par_key = ".".join(self.parent_key)
-            else:
-                ref_par_key = self.parent_key
-
-            logger.warning(
-                f"[{ref_par_key}] dtypes detected {', '.join(sorted(self.hist.keys()))}"
-            )
-
-    @property
-    def dtype(self):
-        """Get data type conforming to spectrum requirements or with highest count.
-
-        If `str_numeric_override` is enabled and any strings have been seen, returned
-        dtype is forced as str.
-
-        If int and float have been seen, dtype defaults to float.
-        """
-
-        dtype = None
-        if self.hist:
-
-            if len(self.hist.keys()) == 1:
-                dtype = list(self.hist.keys())[0]
-            else:
-                numeric_intersect = self.numeric_types & self.hist.keys()
-
-                if numeric_intersect:
-                    if self.str_numeric_override and "str" in self.hist:
-                        dtype = "str"
-                    elif "float" in numeric_intersect:
-                        dtype = "float"
-
-            if not dtype:
-                dtype, _ = max(self.hist.items(), key=lambda t: t[1])
-
-        return dtype
-
-    def _get_max_comparable(self, prev_value, value, key_func):
-        """Get max value for inputs which can be compared."""
-
-        max_value = None
-        if prev_value is None:
-            max_value = value
-        else:
-            max_value = max(value, prev_value, key=key_func)
-        return max_value
-
-    def _compare_numeric(self, prev_value, value):
-        return self._get_max_comparable(prev_value, value, abs)
-
-    def _compare_str(self, prev_value, value):
-        return self._get_max_comparable(prev_value, value, len)
-
-    def _compare_other_types(self, prev_value, value):
-        return value
-
-    @property
-    def max_value(self):
-        """Get max value for current dtype."""
-
-        _dtype = self.dtype
-        is_numeric = _dtype in self.numeric_types
-
-        if is_numeric and self.numeric_types.issubset(self.hist.keys()):
-            val = self._compare_numeric(self.dtype_max["float"], self.dtype_max["int"])
-            return float(val)
-
-        return self.dtype_max.get(_dtype)
-
-    def _update_dtype_max(self, incoming_dtype, value):
-        """Detect dtype change and store diffs."""
-
-        if incoming_dtype in self.dtype_max:
-            prev_value = self.dtype_max[incoming_dtype]
-
-            comp_func = None
-            if incoming_dtype == "str":
-                comp_func = self._compare_str
-            elif incoming_dtype in self.numeric_types:
-                comp_func = self._compare_numeric
-            else:
-                comp_func = self._compare_other_types
-
-            self.dtype_max[incoming_dtype] = comp_func(prev_value, value)
-
-        else:
-            self.dtype_max[incoming_dtype] = value
-
-    def add(self, value):
-        """Add value to field and track dtype."""
-
-        if value is not None:
-            incoming_dtype = type(value).__name__
-            self._update_dtype_max(incoming_dtype, value)
-            self._dtype = incoming_dtype
-            self.hist[self._dtype] += 1
-        else:
-            self.num_na += 1
 
 
 # --------------------------------------------------------------------------------------

--- a/spectron/__init__.py
+++ b/spectron/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
 
-__version__ = "0.4.4"
+__version__ = "0.4.5"
 
 from . import ddl  # noqa: F401

--- a/spectron/merge.py
+++ b/spectron/merge.py
@@ -7,12 +7,8 @@ def pk(parent: Optional[Union[Tuple[str], List[str]]], key: str) -> Tuple[str]:
     """Construct chained parent key as list of strings."""
 
     if parent:
-        parent = [*parent]
-    else:
-        parent = []
-
-    parent.append(key)
-    return tuple(parent)
+        return tuple((*parent, key))
+    return tuple((key,))
 
 
 def terminal(v: Any) -> bool:

--- a/tests/test_Field.py
+++ b/tests/test_Field.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from spectron.MaxDict import Field
+from spectron.Field import Field
 
 
 none__vals = [None, None]

--- a/tests/test_MaxDict.py
+++ b/tests/test_MaxDict.py
@@ -28,3 +28,34 @@ def test__overrides(vals, expected):
     md = MaxDict()
     md.batch_load_dicts(vals)
     assert md.asdict() == expected
+
+
+def test__add_max_dicts():
+    d1 = {
+        "a1": {"b1": 1, "b2": "test", "b3": "x"},
+        "a2": -100,
+        "a3": {"b3": [{"c3": False}]},
+        "a4": 1.234,
+    }
+    d2 = {
+        "a1": {"b1": 10 ** 10, "b2": "x", "b3": "test"},
+        "a2": 1,
+        "a3": {"b3": [{"c3": True}]},
+        "a4": 2.345,
+    }
+
+    md1 = MaxDict()
+    md1.load_dict(d1)
+    md2 = MaxDict()
+    md2.load_dict(d2)
+
+    mdx = md1 + md2
+
+    expected = {
+        "a1": {"b1": 10000000000, "b2": "test", "b3": "test"},
+        "a2": -100,
+        "a3": {"b3": [{"c3": True}]},
+        "a4": 2.345,
+    }
+
+    assert mdx.asdict() == expected

--- a/tests/test_MaxDict.py
+++ b/tests/test_MaxDict.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+from spectron.MaxDict import MaxDict
+
+
+d_no_array_3 = {"a": {"b": {"c": 1}}}
+d_no_array_4 = {"a": {"b": {"c": {"d": 1}}}}
+d_array_nested = {"a": {"b": [{"c": 1}]}}
+d_terminal_array = {"a": {"b": {"c": [1]}}}
+
+
+@pytest.mark.parametrize(
+    "vals, expected",
+    [
+        # test terminal override
+        ([d_no_array_3, d_no_array_4], {"a": {"b": {"c": {"d": 1}}}},),
+        # test array override
+        ([d_no_array_3, d_array_nested], {"a": {"b": [{"c": 1}]}},),
+        # test terminal override with array key
+        ([d_no_array_3, d_terminal_array], {"a": {"b": {"c": [1]}}},),
+        # test non-array override
+        ([d_no_array_3, d_no_array_3, d_array_nested], {"a": {"b": {"c": 1}}},),
+    ],
+)
+def test__overrides(vals, expected):
+
+    md = MaxDict()
+    md.batch_load_dicts(vals)
+    assert md.asdict() == expected


### PR DESCRIPTION
Detects and resolves 2 data QA issues when dealing with semi reliable JSON.

**Mixed terminal keys:**
- a.b (ignored)
- a.b.c

**Mixed array keys:**
- key group selected by largest number seen
* a.b.[array].d
* a.b.c.d

**Bonus features:**
- MaxDict and Field both support addition e.g.`max_dict = max_dict_1 + max_dict_2 + ...`
